### PR TITLE
Add endpoint RPC/stream to get the call stacks

### DIFF
--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -1080,7 +1080,7 @@ message GetSlotABICallStacksRequest {
 }
 
 // GetSlotABICallStacks response
-message GetSlotABICallStacksRequest {
+message GetSlotABICallStacksResponse {
   // TODO
   string todo = 1; 
 }

--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -151,6 +151,14 @@ service PublicService {
     };
   }
 
+  // Get ABI call stack of an operation
+  rpc GetOperationABICallStacks(GetOperationABICallStackRequest) returns (GetOperationABICallStackResponse) {
+    option (google.api.http) = {
+      post: "/v1/get_operation_abi_call_stacks"
+      body: "*"
+    };
+  }
+
   // ███████╗████████╗██████╗ ███████╗ █████╗ ███╗   ███╗
   // ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██╔══██╗████╗ ████║
   // ███████╗   ██║   ██████╔╝█████╗  ███████║██╔████╔██║
@@ -1005,4 +1013,54 @@ message SearchOperationsFilter {
 message SearchOperationsResponse {
   // Information about the operations
   repeated massa.model.v1.OperationInfo operation_infos = 1;
+}
+
+// GetOperationABICallStacks request
+message GetOperationABICallStacksRequest {
+  // Operations ids to get the call stack from
+  repeated string operation_ids = 1;
+}
+
+// Definition of an ABI call stack element
+message ABICallStackElement {
+  // name of the ABI
+  string name = 1;
+  // Parameters of the ABI
+  repeated string parameters = 2;
+  // Return value of the ABI
+  string return_value = 3;
+}
+
+// Definition of an ABI call stack element that is the 'call' ABI
+message ABICallStackElementCall {
+  // name of the ABI
+  string name = 1;
+  // Parameters of the ABI
+  repeated string parameters = 2;
+  // Calls made within this SC call
+  repeated ABICallStackElementParent sub_calls = 3;
+  // Return value of the ABI
+  string return_value = 4;
+}
+
+// Definition of an ABI call stack element parent
+message ABICallStackElementParent {
+  // Element of the call stack
+  oneof call_stack_element {
+    // Any ABI call that is not the ABI 'call'
+    ABICallStackElement element = 1;
+    // Element that is the ABI 'call'
+    ABICallStackElementCall element_call = 2;
+  }
+}
+
+// Definition of an ABI call stack
+message ABICallStack {
+  // All elements of the call stack
+  repeated ABICallStackElementParent call_stack = 1;
+}
+
+// GetOperationABICallStacks response
+message GetOperationABICallStacksResponse {
+  repeated ABICallStack call_stacks = 1;
 }

--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -892,16 +892,18 @@ message NewSlotExecutionOutputsResponse {
 
 // Finality level to filter on in streams
 enum FinalityLevel {
+  // Unspecified (receive both)
+  FINALITY_LEVEL_UNSPECIFIED = 0;
   // Candidate level
-  CANDIDATE = 0;
+  FINALITY_LEVEL_CANDIDATE = 1;
   // Final level
-  FINAL = 1;
+  FINALITY_LEVEL_FINAL = 2;
 }
 
 // NewSlotABICallStacks request
 message NewSlotABICallStacksRequest {
   // Finality level to receive informations from
-  optional FinalityLevel finality_level = 1;
+  FinalityLevel finality_level = 1;
 }
 
 // NewSlotABICallStacks response

--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -893,9 +893,9 @@ message NewSlotExecutionOutputsResponse {
 // Finality level to filter on in streams
 enum FinalityLevel {
   // Candidate level
-  CANDIDATE = 1;
+  CANDIDATE = 0;
   // Final level
-  FINAL = 2;
+  FINAL = 1;
 }
 
 // NewSlotABICallStacks request

--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -159,7 +159,7 @@ service PublicService {
     };
   }
 
-  // Get ABI call stack of all asynchronous message and all operations for a given slot
+  // Get ABI call stack of all asynchronous executions and all operations for a given slot
   rpc GetSlotABICallStacks(GetSlotABICallStacksRequest) returns (GetSlotABICallStacksResponse) {
     option (google.api.http) = {
       post: "/v1/get_slot_abi_call_stacks"
@@ -1079,8 +1079,26 @@ message GetSlotABICallStacksRequest {
   repeated massa.model.v1.Slot slots = 1;
 }
 
+// ABI asynchronous execution call stack 
+message ASCABICallStack {
+  // Index of the execution in the slot
+  uint64 index = 1;
+  // Call stack
+  repeated ABICallStackElementParent call_stack = 2;
+}
+
+// Operation execution call stack
+message OperationABICallStack {
+  // Operation id
+  string operation_id = 1;
+  // Call stack
+  repeated ABICallStackElementParent call_stack = 2;
+}
+
 // GetSlotABICallStacks response
 message GetSlotABICallStacksResponse {
-  // TODO
-  string todo = 1; 
+  // Call stacks for asynchronous execution 
+  repeated ASCABICallStack asc_call_stacks = 1;
+  // Call stack for operations
+  repeated OperationABICallStack operation_call_stacks = 2;
 }

--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -188,6 +188,9 @@ service PublicService {
   // New received and slot execution events
   rpc NewSlotExecutionOutputs(stream NewSlotExecutionOutputsRequest) returns (stream NewSlotExecutionOutputsResponse) {}
 
+  // Call stack for each slot executed
+  rpc NewSlotABICallStacks(stream NewSlotABICallStacksRequest) returns (stream NewSlotABICallStacksResponse) {}
+
   // Send blocks
   rpc SendBlocks(stream SendBlocksRequest) returns (stream SendBlocksResponse) {}
 
@@ -885,6 +888,30 @@ message LedgerChangesFilter {
 message NewSlotExecutionOutputsResponse {
   // Slot execution output
   massa.model.v1.SlotExecutionOutput output = 1;
+}
+
+// Finality level to filter on in streams
+enum FinalityLevel {
+  // Candidate level
+  CANDIDATE = 1;
+  // Final level
+  FINAL = 2;
+}
+
+// NewSlotABICallStacks request
+message NewSlotABICallStacksRequest {
+  // Finality level to receive informations from
+  optional FinalityLevel finality_level = 1;
+}
+
+// NewSlotABICallStacks response
+message NewSlotABICallStacksResponse {
+  // Finality level to receive informations from
+  massa.model.v1.Slot slot = 1;
+  // Call stacks for asynchronous execution 
+  repeated ASCABICallStack asc_call_stacks = 2;
+  // Call stack for operations
+  repeated OperationABICallStack operation_call_stacks = 3;
 }
 
 // SendBlocksRequest holds parameters to SendBlocks

--- a/proto/apis/massa/api/v1/public.proto
+++ b/proto/apis/massa/api/v1/public.proto
@@ -152,9 +152,17 @@ service PublicService {
   }
 
   // Get ABI call stack of an operation
-  rpc GetOperationABICallStacks(GetOperationABICallStackRequest) returns (GetOperationABICallStackResponse) {
+  rpc GetOperationABICallStacks(GetOperationABICallStacksRequest) returns (GetOperationABICallStacksResponse) {
     option (google.api.http) = {
       post: "/v1/get_operation_abi_call_stacks"
+      body: "*"
+    };
+  }
+
+  // Get ABI call stack of all asynchronous message and all operations for a given slot
+  rpc GetSlotABICallStacks(GetSlotABICallStacksRequest) returns (GetSlotABICallStacksResponse) {
+    option (google.api.http) = {
+      post: "/v1/get_slot_abi_call_stacks"
       body: "*"
     };
   }
@@ -1063,4 +1071,16 @@ message ABICallStack {
 // GetOperationABICallStacks response
 message GetOperationABICallStacksResponse {
   repeated ABICallStack call_stacks = 1;
+}
+
+// GetSlotABICallStacks request
+message GetSlotABICallStacksRequest {
+  // Slots asked
+  repeated massa.model.v1.Slot slots = 1;
+}
+
+// GetSlotABICallStacks response
+message GetSlotABICallStacksRequest {
+  // TODO
+  string todo = 1; 
 }


### PR DESCRIPTION
2 RPC : 
- Get call stack by op id
- Get call stack for a whole slot (all asc and all operation)

1 stream : 
- Get all stacks for all slots (filter candidate final)